### PR TITLE
Cannot create webrtc session

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,9 +3,9 @@ CFLAGS = $(shell pkg-config --cflags glib-2.0) -Ijanus-gateway
 CXXFLAGS = $(CFLAGS)
 lib_LTLIBRARIES = libjanus_audioroom.la
 libjanus_audioroom_la_SOURCES = libjanus_audioroom.c
-libjanus_audioroom_la_LDFLAGS = -version-info 0:0:0 $(shell pkg-config --libs glib-2.0)
+libjanus_audioroom_la_LDFLAGS = -version-info 0:0:0 $(shell pkg-config --libs glib-2.0 opus)
 
-LIBS = $(shell pkg-config --libs glib-2.0)
+LIBS = $(shell pkg-config --libs opus glib-2.0)
 
 confdir = $(exec_prefix)/etc/janus
 libdir = $(exec_prefix)/lib/janus/plugins


### PR DESCRIPTION
Steps to reproduce:
1. create session
2. attach plugin
3. create room
4. join the room

Join makes Janus crash
```
[Tue Nov 10 14:58:41 2015] No WebRTC media anymore
[Tue Nov 10 14:58:44 2015] Cleaning up handle 532820311...
[Tue Nov 10 14:58:44 2015] [532820311] WebRTC resources freed
[Tue Nov 10 14:58:44 2015] [532820311] Handle and related resources freed
[Tue Nov 10 14:58:48 2015] Creating new session: 128603952
[Tue Nov 10 14:58:48 2015] Creating new handle in session 128603952: 2193966377
[Tue Nov 10 14:58:49 2015] [ERR] [libjanus_audioroom.c:cm_audioroom_handle_message:1097] Room 1234 already exists!
/usr/bin/janus: symbol lookup error: /usr/lib64/janus/plugins/libjanus_audioroom.so: undefined symbol: opus_encoder_create
---------------------------------------------------
  Starting Meetecho Janus (WebRTC Gateway) v0.0.9
---------------------------------------------------
```

@vogdb fyi