### PR TITLE
Configurtion: fix config file name and plugin name

### DIFF
--- a/libjanus_audioroom.c
+++ b/libjanus_audioroom.c
@@ -387,7 +387,7 @@ record_file =	/path/to/recording.wav (where to save the recording)
 #define CM_AUDIOROOM_DESCRIPTION		"This is a plugin implementing an audio conference bridge for Janus, mixing Opus streams."
 #define CM_AUDIOROOM_NAME				"JANUS CM audio plugin"
 #define CM_AUDIOROOM_AUTHOR			"Meetecho s.r.l."
-#define CM_AUDIOROOM_PACKAGE			"janus.plugin.audioroom"
+#define CM_AUDIOROOM_PACKAGE			"janus.cm.plugin.audioroom"
 
 /* Plugin methods */
 janus_plugin *create(void);


### PR DESCRIPTION
- currently `make install` the config with name `janus.plugin.cm.audioroom.cfg` but it expects to be `janus.plugin.audioroom.cfg` (no `cm` prefix)
- also the plugin name to which we attach is inconsistent with other plugin