### PR TITLE
Use Glib formatting

### DIFF
--- a/conf/janus.plugin.cm.audioroom.cfg.sample
+++ b/conf/janus.plugin.cm.audioroom.cfg.sample
@@ -6,15 +6,18 @@
 
 ; prinf pattern for job filenames (.json is auto)
 ; Short usage, the following gets substituted:
-; %1$llu  is timestamp (guint64)
-; %2$lu   is random integer (guin32)
-; %3$s    is md5 of (timestamp + plugin name + random integer)
-; %4$s    is plugin name ("janus.plugin.cm.audioroom")
-; job_pattern = "job-%3$s"
+; #{time}     is timestamp (guint64)
+; #{rand}     is random integer (guin32)
+; #{md5}      is md5 of (timestamp + plugin name + random integer)
+; #{plugin}   is plugin name ("janus.plugin.cm.rtpbroadcast")
+; job_pattern = "job-#{md5}"
+
+; Path for recording and thumbnailing
+; archive_path = "/tmp/recordings"
 
 ; printf pattern for recordings filenames
 ; Short usage, the following gets substituted:
-; %1$s    is streamChannelKey (string)
-; %2$llu  is timestamp (guint64)
-; %3$s    is type ("audio", "video" or "thumb" string)
-; recording_pattern = "rec-%1$s-%2$llu-%3$s"
+; #{id}       is streamChannelKey (string)
+; #{time}     is timestamp (guint64)
+; #{type}     is type ("audio", "video" or "thumb" string)
+; recording_pattern = "rec-#{id}-#{time}-#{type}"


### PR DESCRIPTION
`snprintf` doesn't play nice with positional arguments when some of them are omitted. Replacing all pattern substitution with Glib one. Low prio right now.