### PR TITLE
Bugs overview

### DIFF
--- a/conf/janus.plugin.cm.audioroom.cfg.sample
+++ b/conf/janus.plugin.cm.audioroom.cfg.sample
@@ -2,7 +2,7 @@
 ; NOTE: all paths should exist beforehead
 
 ; Path for job JSONs
-; job_path = "/tmp/jobs"
+; job_path = /tmp/jobs
 
 ; prinf pattern for job filenames (.json is auto)
 ; Short usage, the following gets substituted:
@@ -10,14 +10,14 @@
 ; #{rand}     is random integer (guin32)
 ; #{md5}      is md5 of (timestamp + plugin name + random integer)
 ; #{plugin}   is plugin name ("janus.plugin.cm.rtpbroadcast")
-; job_pattern = "job-#{md5}"
+; job_pattern = job-#{md5}
 
 ; Path for recording and thumbnailing
-; archive_path = "/tmp/recordings"
+; archive_path = /tmp/recordings
 
 ; printf pattern for recordings filenames
 ; Short usage, the following gets substituted:
 ; #{id}       is streamChannelKey (string)
 ; #{time}     is timestamp (guint64)
 ; #{type}     is type ("audio", "video" or "thumb" string)
-; recording_pattern = "rec-#{id}-#{time}-#{type}"
+; recording_pattern = rec-#{id}-#{time}-#{type}


### PR DESCRIPTION
After first test we have problem with:

##### configfile
```
[Fri Nov 13 14:47:58 2015] [WARN] Recording requested, but could NOT open file "/var/lib/janus/recordings"/"rec-1235-1923329656852-audioroom" for writing...

```
we have to update default configuration file. there should be:
```
job_path=/var/lib/janus/jobs/
archive_path=/var/lib/janus/recordings/
```
instead of (removed `double-quotas`)
```
job_path = "/tmp/jobs"
archive_path = "/tmp/recordings"
```

##### filenames

We should remove `double-quotas` fro filenames?

- recordings

```
ls -lap /var/lib/janus/recordings/
total 1656
drwxr-xr-x 2 root root   4096 Nov 13 15:09 ./
drwxr-xr-x 4 root root   4096 Nov 13 14:49 ../
-rw-r--r-- 1 root root 849324 Nov 13 15:08 "rec-1237-1924512546374-audioroom"
-rw-r--r-- 1 root root 835244 Nov 13 15:09 "rec-fdkjhgfdklghldkjfhglkjdf-1924596583702-audioroom"
```

- jobs
```
$ ls -lap /var/lib/janus/jobs/      
total 16
drwxr-xr-x 2 root root 4096 Nov 13 15:09 ./
drwxr-xr-x 4 root root 4096 Nov 13 14:49 ../
-rw-r--r-- 1 root root  204 Nov 13 15:08 "job-2ec74200e0b33fb0b2693ddf353ce644".json
-rw-r--r-- 1 root root  244 Nov 13 15:09 "job-63b2323bb846f0f0e694f23b2f68b71b".json
```

##### job file
Fix paths?
```
{
    "data": {
        "id": "fdkjhgfdklghldkjfhglkjdf",
        "audio": "/var/lib/janus/recordings//\"rec-fdkjhgfdklghldkjfhglkjdf-1924596583702-audioroom\""
    },
    "plugin": "janus.plugin.cm.audioroom",
    "event": "archive-finished"
}
```
##### destroy
When we destroy session, the room is not destroyed so the `recording` file and `jobs` file is not closed