### PR TITLE
Unexpected error on detach

### DIFF
--- a/libjanus_audioroom.c
+++ b/libjanus_audioroom.c
@@ -2789,7 +2789,7 @@ void cm_audioroom_store_event(json_t* response, const char *event_name) {
 	g_free(fname);
 
 	if (json_dump_file(envelope, fullpath, JSON_INDENT(4)))
-		JANUS_LOG(LOG_ERR, "Error saving JSON to %s", fullpath);
+		JANUS_LOG(LOG_ERR, "Error saving JSON to %s\n", fullpath);
 
 	json_decref(envelope);
 }


### PR DESCRIPTION
When an audio plugin is detached, maybe also when the stream is not established yet, we get this error in janus logs:

```
[Thu Dec 10 13:12:41 2015] Detaching handle from JANUS CM audio plugin                                                                                                                                                                                                    
[Thu Dec 10 13:12:41 2015] [ERR] [libjanus_audioroom.c:cm_audioroom_store_event:2792] Error saving JSON to /var/lib/janus/jobs/job-eb0b51be6b8c1fe63cb54646f4812923.json[Thu Dec 10 13:12:41 2015] No WebRTC media anymore                                                │
[Thu Dec 10 13:12:45 2015] Cleaning up handle 3909645797...
```