### PR TITLE
Failure on detach

### DIFF
--- a/libjanus_audioroom.c
+++ b/libjanus_audioroom.c
@@ -866,7 +866,7 @@ void cm_audioroom_destroy_session(janus_plugin_session *handle, int *error) {
 		//	session->rooms = NULL;
 		//}
 
-	 cm_audioroom_participant *participant = (cm_audioroom_participant *)session->participant;
+		cm_audioroom_participant *participant = (cm_audioroom_participant *)session->participant;
 		if (participant) {
 				cm_audioroom_room *audioroom = participant->room;
 				if (audioroom && !audioroom->destroy && !audioroom->destroyed) {

--- a/libjanus_audioroom.c
+++ b/libjanus_audioroom.c
@@ -866,17 +866,19 @@ void cm_audioroom_destroy_session(janus_plugin_session *handle, int *error) {
 		//	session->rooms = NULL;
 		//}
 
-		cm_audioroom_participant *participant = (cm_audioroom_participant *)session->participant;
+	 cm_audioroom_participant *participant = (cm_audioroom_participant *)session->participant;
 		if (participant) {
-			cm_audioroom_room *audioroom = participant->room;
-			if (audioroom) {
-				janus_mutex_lock(&audioroom->mutex);
-				int participant_count = g_hash_table_size(audioroom->participants);
-				janus_mutex_unlock(&audioroom->mutex);
-				if (participant_count == 1) {
-					cm_audioroom_room_destroy(audioroom, NULL);
+				cm_audioroom_room *audioroom = participant->room;
+				if (audioroom && !audioroom->destroy && !audioroom->destroyed) {
+						janus_mutex_lock(&audioroom->mutex);
+						int participant_count = g_hash_table_size(audioroom->participants);
+						janus_mutex_unlock(&audioroom->mutex);
+						if (participant_count <= 1) {
+								JANUS_LOG(LOG_INFO, "Auto removal of room (%s), no more participants\n", audioroom->room_id);
+								janus_mutex_lock(&rooms_mutex);
+								cm_audioroom_room_destroy(audioroom, NULL);
+						}
 				}
-			}
 		}
 
 		g_hash_table_remove(sessions, handle);
@@ -2074,11 +2076,15 @@ static void *cm_audioroom_handler(void *data) {
 			}
 
 			/* If we change the room and old room stay empty then let's remove that room */
-			if (old_audioroom) {
-				if (g_hash_table_size(old_audioroom->participants) == 0) {
-					JANUS_LOG(LOG_INFO, "Auto removal of room (%s), no more participants\n", old_audioroom->room_id);
-					cm_audioroom_room_destroy(old_audioroom, NULL);
-				}
+			if (old_audioroom && !old_audioroom->destroy && !old_audioroom->destroyed) {
+					janus_mutex_lock(&old_audioroom->mutex);
+					int participant_count = g_hash_table_size(old_audioroom->participants);
+					janus_mutex_unlock(&old_audioroom->mutex);
+					if (participant_count < 1) {
+							JANUS_LOG(LOG_INFO, "Auto removal of room (%s), no more participants\n", old_audioroom->room_id);
+							janus_mutex_lock(&rooms_mutex);
+							cm_audioroom_room_destroy(old_audioroom, NULL);
+					}
 			}
 
 			event = json_object();


### PR DESCRIPTION
```
[Sat Jan 16 15:23:24 2016] [WSS-0x135a300] Got 157 bytes:
[Sat Jan 16 15:23:24 2016] {"janus":"detach","transaction":"nHdluWfn9gT0","token":"{\"sessionId\":\"821f008073ed3fb2dc3bb1d68cccf988\"}","session_id":3591550569,"handle_id":3216666938}
[Sat Jan 16 15:23:24 2016] Got a Janus API request from janus.transport.websockets (0x1359760)
[Sat Jan 16 15:23:24 2016] Sending WebSocket message (105 bytes)...
[Sat Jan 16 15:23:24 2016]   -- Sent 105/105 bytes
[Sat Jan 16 15:23:24 2016] Sending WebSocket message (275 bytes)...
[Sat Jan 16 15:23:24 2016]   -- Sent 275/275 bytes
[Sat Jan 16 15:23:24 2016] Sending WebSocket message (105 bytes)...
[Sat Jan 16 15:23:24 2016]   -- Sent 105/105 bytes
[Sat Jan 16 15:23:24 2016] [3216666938] ICE send thread leaving...
[Sat Jan 16 15:23:24 2016] [4007898039] ICE send thread leaving...
[Sat Jan 16 15:23:24 2016] Transport task pool, serving request
[Sat Jan 16 15:23:24 2016] Detaching handle from JANUS CM audio plugin
[Sat Jan 16 15:23:24 2016] Removing AudioBridge session...
[Sat Jan 16 15:23:24 2016] No WebRTC media anymore
[Sat Jan 16 15:23:24 2016] Auto removal of room (.0z3mK25HAtDYip80wTM6g__), no more participants
[Sat Jan 16 15:23:24 2016] Notifying all participants
[Sat Jan 16 15:23:24 2016] Waiting for the mixer thread to complete...
[Sat Jan 16 15:23:24 2016] Leaving mixer thread for room .0z3mK25HAtDYip80wTM6g__ (Room .0z3mK25HAtDYip80wTM6g__)...
[Sat Jan 16 15:23:24 2016] [3216666938] Sending event to transport...
[Sat Jan 16 15:23:24 2016] Sending event to janus.transport.websockets (0x1359760)
[Sat Jan 16 15:23:24 2016] [3216666938] Handle detached (error=0), scheduling destruction
[Sat Jan 16 15:23:24 2016] AudioBridge Participant thread leaving...
[Sat Jan 16 15:23:24 2016] Sending Janus API response to janus.transport.websockets (0x1359760)
[Sat Jan 16 15:23:24 2016] [WSS-0x14f1060] Got 157 bytes:
[Sat Jan 16 15:23:24 2016] {"janus":"detach","transaction":"piaMqvEefezw","token":"{\"sessionId\":\"89d423f6409f74bc737e4d38f95534e3\"}","session_id":3392815671,"handle_id":4007898039}
[Sat Jan 16 15:23:24 2016] Got a Janus API request from janus.transport.websockets (0x152b570)
[Sat Jan 16 15:23:24 2016] Sending WebSocket message (80 bytes)...
[Sat Jan 16 15:23:24 2016]   -- Sent 80/80 bytes
[Sat Jan 16 15:23:24 2016] Sending WebSocket message (88 bytes)...
[Sat Jan 16 15:23:24 2016]   -- Sent 88/88 bytes
[Sat Jan 16 15:23:24 2016] Transport task pool, serving request
[Sat Jan 16 15:23:24 2016] Detaching handle from JANUS CM audio plugin
[Sat Jan 16 15:23:24 2016] Removing AudioBridge session...
[Sat Jan 16 15:23:24 2016] No WebRTC media anymore
Segmentation fault (core dumped)
```