### PR TITLE
Send a proper response to client offer

### DIFF
--- a/libjanus_audioroom.c
+++ b/libjanus_audioroom.c
@@ -2206,6 +2206,14 @@ static void *cm_audioroom_handler(void *data) {
 				participant->opus_pt,			/* Opus payload type */
 				participant->opus_pt, 			/* Opus payload type and room sampling rate */
 				participant->room->sampling_rate);
+
+			if (g_strrstr(msg->sdp, "a=recvonly") != NULL) {
+				g_strlcat(sdp, "a=sendonly\r\n", 1024);
+			} else if (g_strrstr(msg->sdp, "a=sendonly") != NULL) {
+				g_strlcat(sdp, "a=recvonly\r\n", 1024);
+			}
+			/* sendrecv case will be processed by default */
+
 			/* Did the peer negotiate video? */
 			if(strstr(msg->sdp, "m=video") != NULL) {
 				/* If so, reject it */

--- a/test/tester.py
+++ b/test/tester.py
@@ -91,4 +91,4 @@ def session():
     greet()
     attach()
     destroy()
-    create()
+    join()


### PR DESCRIPTION
On Firefox, we get this error when the client try to connect to an audio channel:
```
InvalidSessionDescriptionError: Answer tried to set send when offer did not set recv
```

The reason seems to be that the `audioroom` plugin is sending an offer with `a=sendrecv` when it should be only `a=sendonly` or `a=recvonly`, like in the client offer...


client offer:
```
v=0
o=mozilla...THIS_IS_SDPARTA-44.0.2 4523299561066025153 0 IN IP4 0.0.0.0
s=-
t=0 0
a=fingerprint:sha-256 1F:89:41:A2:81:FA:05:57:A9:26:7C:B0:80:E8:3C:8D:5F:AE:96:93:8A:D3:02:88:12:85:C4:23:34:F4:F3:E0
a=ice-options:trickle
a=msid-semantic:WMS *
m=audio 9 UDP/TLS/RTP/SAVPF 109 9 0 8
c=IN IP4 0.0.0.0
a=recvonly
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=ice-pwd:e704056f6857895dc58aa96e4149ee37
a=ice-ufrag:d94a8a8f
a=mid:sdparta_0
a=rtcp-mux
a=rtpmap:109 opus/48000/2
a=rtpmap:9 G722/8000/1
a=rtpmap:0 PCMU/8000
a=rtpmap:8 PCMA/8000
a=setup:actpass
a=ssrc:1452185086 cname:{e110de59-59ab-164e-ba08-5a7d54196ad3}
```

`audioroom` plugin offer:
```
v=0
o=- 1459865320083059 1459865320083008 IN IP4 127.0.0.1
s=Room D-jwP3PAhOJ15ORJtWdKpQ__
t=0 0
a=group:BUNDLE sdparta_0
a=msid-semantic: WMS janus
m=audio 1 UDP/TLS/RTP/SAVPF 109
c=IN IP4 127.0.0.1
a=mid:sdparta_0
a=sendrecv
a=rtcp-mux
a=ice-ufrag:LSRL
a=ice-pwd:1F5xQALIYIfPsvi+PaVHPV
a=ice-options:trickle
a=fingerprint:sha-256 85:7E:F6:AD:D1:2B:A7:09:AD:D6:84:DF:19:B1:D5:41:A2:B7:57:50:12:96:EE:E0:A8:A8:68:3D:6F:1A:C3:21
a=setup:active
a=connection:new
a=rtpmap:109 opus/48000/2
a=fmtp:109 maxplaybackrate=48000; stereo=0; sprop-stereo=0; useinbandfec=0
a=ssrc:1599361869 cname:janusaudio
a=ssrc:1599361869 msid:janus janusa0
a=ssrc:1599361869 mslabel:janus
a=ssrc:1599361869 label:janusa0
a=candidate:1 1 udp 2013266431 10.0.2.15 36357 typ host
a=candidate:2 1 udp 2013266431 10.10.11.10 57651 typ host
a=candidate:3 1 udp 2013266431 192.168.1.28 34698 typ host
```

see https://github.com/cargomedia/sk/issues/3196